### PR TITLE
Use the lua interpreter directly instead of through env

### DIFF
--- a/filters.kak
+++ b/filters.kak
@@ -73,7 +73,7 @@ define-command peneira-symbols -docstring %{
 
     peneira 'symbols: ' %{
         export LUA_PATH="$kak_opt_peneira_path/?.lua"
-        env lua=$kak_opt_luar_interpreter "$kak_opt_peneira_path/filters" symbols "$kak_buffile"
+        $kak_opt_luar_interpreter "$kak_opt_peneira_path/filters.lua" symbols "$kak_buffile"
     } %{
         lua %arg{1} %val{buffile} %opt{peneira_path} %{
             addpackagepath(arg[3])
@@ -138,7 +138,7 @@ define-command peneira-lines -docstring %{
 
         peneira -no-rank 'lines: ' %{
             export LUA_PATH="$kak_opt_peneira_path/?.lua"
-            env lua=$kak_opt_luar_interpreter "$kak_opt_peneira_path/filters" lines $kak_reg_dquote
+            $kak_opt_luar_interpreter "$kak_opt_peneira_path/filters.lua" lines $kak_reg_dquote
         } %{
             execute-keys %sh{ echo $1 | awk '{ print $1 }' }gx
         }

--- a/filters.kak
+++ b/filters.kak
@@ -73,7 +73,7 @@ define-command peneira-symbols -docstring %{
 
     peneira 'symbols: ' %{
         export LUA_PATH="$kak_opt_peneira_path/?.lua"
-        $kak_opt_luar_interpreter "$kak_opt_peneira_path/filters.lua" symbols "$kak_buffile"
+        exec $kak_opt_luar_interpreter "$kak_opt_peneira_path/filters.lua" symbols "$kak_buffile"
     } %{
         lua %arg{1} %val{buffile} %opt{peneira_path} %{
             addpackagepath(arg[3])
@@ -138,7 +138,7 @@ define-command peneira-lines -docstring %{
 
         peneira -no-rank 'lines: ' %{
             export LUA_PATH="$kak_opt_peneira_path/?.lua"
-            $kak_opt_luar_interpreter "$kak_opt_peneira_path/filters.lua" lines $kak_reg_dquote
+            exec $kak_opt_luar_interpreter "$kak_opt_peneira_path/filters.lua" lines $kak_reg_dquote
         } %{
             execute-keys %sh{ echo $1 | awk '{ print $1 }' }gx
         }

--- a/filters.kak
+++ b/filters.kak
@@ -73,7 +73,7 @@ define-command peneira-symbols -docstring %{
 
     peneira 'symbols: ' %{
         export LUA_PATH="$kak_opt_peneira_path/?.lua"
-        exec $kak_opt_luar_interpreter "$kak_opt_peneira_path/filters.lua" symbols "$kak_buffile"
+        $kak_opt_luar_interpreter "$kak_opt_peneira_path/filters.lua" symbols "$kak_buffile"
     } %{
         lua %arg{1} %val{buffile} %opt{peneira_path} %{
             addpackagepath(arg[3])
@@ -138,7 +138,7 @@ define-command peneira-lines -docstring %{
 
         peneira -no-rank 'lines: ' %{
             export LUA_PATH="$kak_opt_peneira_path/?.lua"
-            exec $kak_opt_luar_interpreter "$kak_opt_peneira_path/filters.lua" lines $kak_reg_dquote
+            $kak_opt_luar_interpreter "$kak_opt_peneira_path/filters.lua" lines $kak_reg_dquote
         } %{
             execute-keys %sh{ echo $1 | awk '{ print $1 }' }gx
         }

--- a/filters.lua
+++ b/filters.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env lua
-
 -- This executable is an auxiliary tool for peneira-symbols and peneira-lines.
 --
 -- For peneira-symbols, it builds a tree of tags from ctags output to print


### PR DESCRIPTION
Doing it the original way (with `env lua=$path filter`) doesn't work, at least on MacOS...

I need it because I don't have a `lua` binary in my `$PATH` (I set `lua_interpreter` with Nix's `pkgs.luajit`).
