### PR TITLE
Fix crash when number-lines highlighter doesn't exist

### DIFF
--- a/peneira.kak
+++ b/peneira.kak
@@ -174,7 +174,7 @@ define-command -hidden peneira-fill-buffer %{
 
 # Configure highlighters and mappings
 define-command -hidden peneira-configure-buffer %{
-    remove-highlighter window/number-lines
+    try %{ remove-highlighter window/number-lines }
     add-highlighter buffer/peneira-matches ranges peneira_matches
     add-highlighter buffer/peneira-flag flag-lines @PeneiraFlag peneira_flag
     face window PrimaryCursor @PeneiraSelected


### PR DESCRIPTION
Restores behavior before
https://github.com/mawww/kakoune/commit/b1c114bf6d950684df0524e450782a151e6a0323

Fixes #18 