### PR TITLE
removed explicit require-module call from autoloading code

### DIFF
--- a/peneira.kak
+++ b/peneira.kak
@@ -2,8 +2,6 @@ declare-option -hidden str peneira_path %sh{ dirname $kak_source }
 
 provide-module peneira-core %◍
 
-require-module luar
-
 declare-option -hidden int peneira_selected_line 1 # used to track the selected line
 declare-option -hidden line-specs peneira_flag # used to flag selected line
 declare-option -hidden range-specs peneira_matches # used to highlight matches


### PR DESCRIPTION
The call to `require-module luar` in `peneira.kak` causes conflicts when loading the plugin with `kak-bundle`. If a module depends on another, I think it's bad practice to explicitly `require` it since the require call is global and can cause conflicts with other plugins. Instead, the require call should be assumed to be done by the user.