### PR TITLE
fix quoting when passing string to shell `eval`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ here is a simple `buffers` filter to go to a buffer in the buffer list:
 
 ```kak
 define-command buffers %{
-    peneira 'buffers: ' %{ printf '%s\n' $kak_quoted_buflist } %{
+    peneira 'buffers: ' %{ eval "printf '%s\n' $kak_quoted_buflist" } %{
         buffer %arg{1}
     }
 }

--- a/peneira.asciidoc
+++ b/peneira.asciidoc
@@ -19,7 +19,7 @@ here is a simple `buffers` filter to go to a buffer in the buffer list:
 
 ----
 define-command buffers %{
-    peneira 'buffers: ' %{ printf '%s\n' $kak_quoted_buflist } %{
+    peneira 'buffers: ' %{ eval "printf '%s\n' $kak_quoted_buflist" } %{
         buffer %arg{1}
     }
 }
@@ -39,7 +39,7 @@ showing first the results it thinks the user intended. If you want that it respe
 the candidates order instead, you can pass the `-no-rank` switch:
 
 ----
-peneira -no-rank 'buffers: ' %{ printf '%s\n' $kak_quoted_buflist } %{
+peneira -no-rank 'buffers: ' %{ eval "printf '%s\n' $kak_quoted_buflist" } %{
     buffer %arg{1}
 }
 ----

--- a/peneira.kak
+++ b/peneira.kak
@@ -59,7 +59,7 @@ define-command peneira -params 3..4 -docstring %{
 define-command -hidden peneira-finder -params 4 %{
     evaluate-commands -save-regs p %{
         lua %arg{3} %{
-            local command = arg[1]:gsub([["]],[[\"]])
+            local command = arg[1]:gsub([[']],[['\'']])
             -- %arg{3} (the command that generates candidates) may contain
             -- shell expansions. If we use it directly inside %sh{}, Kakoune
             -- doesn't interpret those expansions. E.g., say %arg{3} contains
@@ -81,7 +81,7 @@ define-command -hidden peneira-finder -params 4 %{
                 set-register p %%sh{
                     # Execute command that generates candidates, and populate temp file
                     file=$(mktemp)
-                    eval "%s" > $file
+                    eval '(%s)' > $file
                     # Write file name to register p
                     printf "%%s" $file
                 }


### PR DESCRIPTION
The argument to `eval` is enclosed in double quotes and double quotes within the string are escaped. As any dollar signs in the string are not escaped they will be subject to parameter expansion before the string is evaluated. This means that code such as

    define-command peneira-git-files %{
         peneira 'files: ' %{
            toplevel="$(git -C "${kak_buffile%/*}" rev-parse --show-toplevel 2>/dev/null)"
            pretty_toplevel="~/${toplevel#$HOME/}/"
            git -C "$toplevel" -c core.quotePath=false ls-files | sed "s|^|$pretty_toplevel|"
        }
    }

Does not work because instead of running

    git -C "/path/to/dir" rev-parse ...

it runs

    git -C \"/path/to/dir\" rev-parse ...

In order to work correctly every '$' has to be escaped with a '\' which is unexpected and rather confusing.

The user's code is also run in the main shell process which means that if it calls `exit` peneira shows no output because the main shell exits early. Fix these two issues by correctly quoting the user's code before passing it to `eval` to suppress parameter expansion and running the code in a subshell so that calling `exit` will exit the subshell and not the main shell. Using a subshell also prevents the user's code from accidentally overwriting shell variables used by peneira.

As this is a breaking change the buffer list example in the documentation that relies on the confusing behavior of expanding variables before passing them to `eval` is updated to accommodate the quoting changes.