### PR TITLE
mru: fix for paths including the working dir path

### DIFF
--- a/filters.kak
+++ b/filters.kak
@@ -191,7 +191,7 @@ try %{
         peneira-files-configure-buffer
 
         peneira 'mru: ' %{
-            grep "$(pwd)" $kak_config/mru_files.txt | sed -e "s!$(pwd)/!!"
+            grep "^$(pwd)" $kak_config/mru_files.txt | sed -e "s!^$(pwd)/!!"
         } %{
             edit %arg{1}
         }


### PR DESCRIPTION
This fixes the MRU path selection and prefix removal in case the `peneira-mru` command is run from a path that is contained in some of the MRU paths.

## Example

`$kak_config/mru_files.txt`:
```
/foo/bar/baz
```

Result when run from `/bar`:
```
/foobaz
```